### PR TITLE
Escape arguments to shell routines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 ===========
-Nake readme
+Nake |travis|
 ===========
+
+.. |travis| image:: https://travis-ci.org/fowlmouth/nake.svg?branch=master
+    :target: https://travis-ci.org/fowlmouth/nake
 
 Describe your `Nim <http://nim-lang.org>`_ builds as tasks. Example
 ``nakefile.nim``:

--- a/nake.nim
+++ b/nake.nim
@@ -43,10 +43,9 @@ when isMainModule:
       nakefileDir = nakeSource.parentDir()
       nakeExe = nakeSource.changeFileExt(ExeExt)
       nakeSelf = getAppFilename()
+      args = @[nakeExe] & commandLineParams()
 
-    var
-      args = join(commandLineParams(), " ")
-      dependencies = @[nakeSource]
+    var dependencies = @[nakeSource]
 
     if nakeSelf.len > 0:
       dependencies.add(nakeSelf)
@@ -57,7 +56,7 @@ when isMainModule:
 
     var res = false
     withDir nakefileDir:
-      res = shell(nakeExe, args)
+      res = shell(args)
     quit (if res: 0 else: 1)
 
   mainExecution()

--- a/nake.nimble
+++ b/nake.nimble
@@ -1,4 +1,4 @@
-version = "1.9.1"
+version = "1.10"
 author = "fowl"
 description = "make-like for Nim. Describe your builds as tasks!"
 license = "MIT"

--- a/nakefile.nim
+++ b/nakefile.nim
@@ -8,7 +8,7 @@ proc mvFile(`from`,to: string) =
 when defined(Linux):
   proc symlinkFile (file, to: string) =
     removeFile(to)
-    direShell("ln -s", file.expandFileName, to)
+    direShell("ln", "-s", file.expandFileName, to)
     echo "Symlinked file"
 
 
@@ -26,10 +26,9 @@ proc buildDocs() =
     let rstDest = rstSrc.changeFileExt(".html")
     if not rstDest.needsRefresh(rstSrc): continue
     direSilentShell(rstSrc & " -> " & rstDest,
-      nimExe & " rst2html --verbosity:0 --index:on -o:" &
-        rstDest & " " & rstSrc)
+      nimExe, "rst2html", "--verbosity:0", "--index:on", "-o:" & rstDest, rstSrc)
 
-  direSilentShell("Building theindex.html", nimExe, "buildIndex .")
+  direSilentShell("Building theindex.html", nimExe, "buildIndex", ".")
 
 
 
@@ -40,12 +39,12 @@ proc runTests() =
     for nakeFile in walkFiles "*.nim":
       let nakeExe = nakeFile.changeFileExt(ExeExt)
       if not shell(nimExe, "c",
-          "--noNimblePath --verbosity:0 -d:debug -r", nakeFile):
+          "--noNimblePath", "--verbosity:0", "-d:debug", "-r", nakeFile):
         testResults.add(false)
         continue
       # Repeat compilation in release mode.
       if not shell(nimExe, "c",
-          "--noNimblePath --verbosity:0 -d:release -r", nakeFile):
+          "--noNimblePath", "--verbosity:0", "-d:release", "-r", nakeFile):
         testResults.add(false)
         continue
       testResults.add(true)
@@ -121,18 +120,18 @@ Or maybe run 'nimble install gh_nimrod_doc_pages'.
   let
     nakeExe = "nakefile".addFileExt(ExeExt)
     ourselves = readFile(nakeExe)
-  direShell gitExe & " checkout gh-pages"
+  direShell gitExe, "checkout", "gh-pages"
   # Keep ingored files http://stackoverflow.com/a/3801554/172690.
   when defined(posix):
-    shell "rm -Rf `git ls-files --others --exclude-standard`"
+    shell "rm", "-Rf", "`git ls-files --others --exclude-standard`"
   removeDir("gh_docs")
-  direShell ghExe & " -c " & iniPathOrDir
+  direShell ghExe, "-c", iniPathOrDir
   writeFile(nakeExe, ourselves)
-  direShell "chmod 775 nakefile"
+  direShell "chmod", "775", "nakefile"
   echo "All commands run, now check the output and commit to git."
   when defined(macosx):
-    shell "open index.html"
-  echo "Wen you are done come back with './" & nakeExe & " postweb'."
+    shell "open", "index.html"
+  echo "Wen you are done come back with './", nakeExe, " postweb'."
 
 
 proc switchBackFromGhPages() =
@@ -142,9 +141,9 @@ proc switchBackFromGhPages() =
     quit("Could not find git binary in $PATH, aborting")
 
   echo "Forcing changes back to master."
-  direShell gitExe & " checkout -f @{-1}"
+  direShell gitExe, "checkout", "-f", "@{-1}"
   echo "Updating submodules just in case."
-  direShell gitExe & " submodule update"
+  direShell gitExe, "submodule", "update"
   removeDir("gh_docs")
 
 


### PR DESCRIPTION
Breaking change.

`*shell` routines now escape their arguments to properly handle arguments with spaces and special chars. The usage pattern which previously escaped the args or concatenated arguments into a single string will now fail.
