### PR TITLE
Add needsRefresh for mutliple targets

### DIFF
--- a/nakelib.nim
+++ b/nakelib.nim
@@ -225,6 +225,38 @@ proc needsRefresh*(target: string, src: varargs[string]): bool {.
     if srcTime > targetTime:
       return true
 
+proc needsRefresh*(targets: seq[string], src: varargs[string]): bool {.raises: [OSError].} =
+  ## Returns true if any ``src`` is newer than the oldest ``targets``.
+  ##
+  ## .. code-block:: nimrod
+  ##   import nake, os
+  ##
+  ##   let
+  ##     src = @["prog.nim", "prog2.nim"]
+  ##     dst = @["prog.out", "prog_stats.txt"]
+  ##   if dst.needsRefresh(src):
+  ##      echo "Refreshing ..."
+  ##      discard
+  ##   else:
+  ##      echo "All done!"
+  assert len(targets) > 0, "Pass some targets to check"
+  assert len(src) > 0, "Pass some source files to check"
+  var minTargetTime: float = -1
+  for target in targets:
+    try:
+      let targetTime = toSeconds(getLastModificationTime(target))
+      if minTargetTime == -1:
+        minTargetTime = targetTime
+      elif targetTime < minTargetTime:
+        minTargetTime = targetTime
+    except OSError:
+      return true
+  
+  for s in src:
+    let srcTime = toSeconds(getLastModificationTime(s))
+    if srcTime > minTargetTime:
+      return true
+
 
 proc newNakeTask(desc: string; action: NakeAction): NakeTask {.raises: [].} =
   result = NakeTask(desc: desc, action: action)

--- a/nakelib.nim
+++ b/nakelib.nim
@@ -236,7 +236,7 @@ proc needsRefresh*(targets: seq[string], src: varargs[string]): bool {.raises: [
   ##     dst = @["prog.out", "prog_stats.txt"]
   ##   if dst.needsRefresh(src):
   ##      echo "Refreshing ..."
-  ##      discard
+  ##      # do something to generate the outputs
   ##   else:
   ##      echo "All done!"
   assert len(targets) > 0, "Pass some targets to check"


### PR DESCRIPTION
For the case when a build step produces multiple targets.  For my case, using `tsc` to compile TypeScript files to JavaScript.