### PR TITLE
Verbose mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,8 @@ specifying a task. Example:
         echo "Binary is fresh, anything else?"
         listTasks()
 
+If you would like verbose output, including printing out the task names and
+shell commands being run, run with ``-v`` or ``--verbose``.
 
 Documentation
 =============

--- a/nake.nim
+++ b/nake.nim
@@ -75,6 +75,8 @@ else:
           validateShellCommands = true
         of "tasks", "t":
           printTaskList = true
+        of "verbose", "v":
+          verboseMode = true
         else:
           discard
       of cmdArgument:

--- a/nakelib.nim
+++ b/nakelib.nim
@@ -82,7 +82,7 @@ proc askShellCMD (cmd: string): bool {.raises: [ValueError,IOError,OSError].} =
       return false
   else:
     if verboseMode:
-      echo "[nake $1] $2" % [getCurrentDir(), cmd]
+      echo "[nake] $1 $2" % [getCurrentDir(), cmd]
     result = execShellCMD(cmd) == 0
 
 

--- a/nakelib.nim
+++ b/nakelib.nim
@@ -43,6 +43,10 @@ var
   ## `direShell() <#direShell>`_ procs to ask the user for confirmation before
   ## executing a command.
 
+  verboseMode* = false ## \
+  ## Set this global to ``true`` if you want to display all tasks and commands
+  ## that are run.
+
   nimExe*: string ## \
   ## Full path to the Nim compiler binary.
   ##
@@ -69,7 +73,7 @@ if nimExe.len < 1:
 nimExe = nimExe.quoteShell()
 
 
-proc askShellCMD (cmd: string): bool {.raises: [ValueError,IOError].} =
+proc askShellCMD (cmd: string): bool {.raises: [ValueError,IOError,OSError].} =
   if validateShellCommands:
     let ans = readLineFromSTDIN("Run? `$#` [N/y]\L" % cmd)
     if ans[0] in {'y','Y'}:
@@ -77,6 +81,8 @@ proc askShellCMD (cmd: string): bool {.raises: [ValueError,IOError].} =
     else:
       return false
   else:
+    if verboseMode:
+      echo "[nake $1] $#" % [getCurrentDir(), cmd]
     result = execShellCMD(cmd) == 0
 
 
@@ -97,11 +103,13 @@ proc askSilentShellCMD(cmd: string):
       result.output = ""
       result.exitCode = -1
   else:
+    if verboseMode:
+      echo "[nake] $#" % cmd
     result = execCmdEx(cmd)
 
 
 proc shell*(cmd: varargs[string, `$`]): bool {.discardable,
-    raises:[ValueError,IOError] .} =
+    raises:[ValueError,IOError,OSError] .} =
   ## Invokes an external command.
   ##
   ## The proc will return ``false`` if the command exits with a non zero code,
@@ -113,7 +121,7 @@ proc shell*(cmd: varargs[string, `$`]): bool {.discardable,
 
 
 proc direShell*(cmd: varargs[string, `$`]): bool {.discardable,
-    raises:[ValueError,IOError].} =
+    raises:[ValueError,IOError,OSError].} =
   ## Wrapper around the `shell() <#shell>`_ proc.
   ##
   ## Instead of returning on a non zero value like `shell() <#shell>`_,
@@ -249,6 +257,8 @@ proc runTask*(name: string) {.inline.} = ## \
   ##     runTask("docs")
   ##     echo "Copying documentation to " & docInstallDir
   ##     copyFile(moduleHtml, docInstallDir / moduleHtml)
+  if verboseMode:
+    echo "[nake] " & name
   tasks[name].action()
 
 

--- a/nakelib.nim
+++ b/nakelib.nim
@@ -82,7 +82,7 @@ proc askShellCMD (cmd: string): bool {.raises: [ValueError,IOError,OSError].} =
       return false
   else:
     if verboseMode:
-      echo "[nake $1] $#" % [getCurrentDir(), cmd]
+      echo "[nake $1] $2" % [getCurrentDir(), cmd]
     result = execShellCMD(cmd) == 0
 
 


### PR DESCRIPTION
This adds a `-v` flag for verbose output.  It replaces PR #66 which contained unrelated changes.