### PR TITLE
fixed to avoid warnings

### DIFF
--- a/nake.nim
+++ b/nake.nim
@@ -17,7 +17,7 @@
 ## example of a simple nakefile
 
 
-import strutils, parseopt, tables, os, rdstdin, times, nakelib
+import strutils, parseopt, tables, os, rdstdin, nakelib
 export strutils, parseopt, tables, os, rdstdin, nakelib
 
 
@@ -35,7 +35,7 @@ when isMainModule:
     ## All the binary does is forward cli arguments to `nim c -r nakefile.nim
     ## $ARGS`
     let nakeSource = findNakefile()
-    if not existsFile(nakeSource):
+    if not fileExists(nakeSource):
       echo "No nakefile.nim found. Current working dir is ", getCurrentDir()
       quit 1
 

--- a/nakelib.nim
+++ b/nakelib.nim
@@ -216,12 +216,12 @@ proc needsRefresh*(target: string, src: varargs[string]): bool {.
   assert len(src) > 0, "Pass some parameters to check for"
   var targetTime: float
   try:
-    targetTime = toUnix(getLastModificationTime(target)).float
+    targetTime = toUnixFloat(getLastModificationTime(target))
   except OSError:
     return true
 
   for s in src:
-    let srcTime = toUnix(getLastModificationTime(s)).float
+    let srcTime = toUnixFloat(getLastModificationTime(s))
     if srcTime > targetTime:
       return true
 


### PR DESCRIPTION
Avoid warnings during installation
"toUnix" changed to "toUnixFloat" for subsecond resolution

Would it be possible to also add a release tag, so I don't get errors when installing via nimble install ... ?
Thx